### PR TITLE
Add validation testcases for VibeCheck

### DIFF
--- a/src/vibechecks/vibecheck.py
+++ b/src/vibechecks/vibecheck.py
@@ -29,11 +29,20 @@ class VibeCheck:
             model: The name of the model to use for the LLM.
             config: VibeCheckConfig containing runtime knobs (e.g., num_tries).
 
+        Raises:
+            ValueError: If `model` is an empty string.
+            TypeError: If `config` is of invalid type.
+
         """
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError("model must be a non-empty string.")
+
         if config is None:
             config = VibeCheckConfig()
         elif isinstance(config, dict):
             config = VibeCheckConfig(**config)
+        elif not isinstance(config, VibeCheckConfig):
+            raise TypeError("config must be a VibeCheckConfig, dict, or None.")
 
         self.llm = VibeLlmClient(client, model, config, console_logger)
 

--- a/tests/test_vibecheck.py
+++ b/tests/test_vibecheck.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from vibetools.exceptions import VibeLlmClientException
 
 from vibechecks.config.config import VibeCheckConfig
 from vibechecks.utils.logger import console_logger
@@ -61,3 +62,33 @@ def test_vibecheck_call_false(mock_vibe_llm_client: Mock):
 
     mock_llm_instance.vibe_eval.assert_called_once_with(statement, bool)
     assert result is False
+
+
+@pytest.mark.parametrize(
+    "client, model, config, error_type",
+    [
+        # Invalid client types - VibeLlmClient validates and raises VibeLlmClientException
+        pytest.param(None, "test-model", VibeCheckConfig(), VibeLlmClientException, id="client_none"),
+        pytest.param("not_a_client", "test-model", VibeCheckConfig(), VibeLlmClientException, id="client_string"),
+        pytest.param(123, "test-model", VibeCheckConfig(), VibeLlmClientException, id="client_int"),
+        pytest.param(["list"], "test-model", VibeCheckConfig(), VibeLlmClientException, id="client_list"),
+
+        # Invalid model types / values - VibeCheck validates and raises ValueError
+        pytest.param(Mock(), None, VibeCheckConfig(), ValueError, id="model_none"),
+        pytest.param(Mock(), "", VibeCheckConfig(), ValueError, id="model_empty"),
+        pytest.param(Mock(), "   ", VibeCheckConfig(), ValueError, id="model_whitespace"),
+        pytest.param(Mock(), 123, VibeCheckConfig(), ValueError, id="model_int"),
+        pytest.param(Mock(), ["model"], VibeCheckConfig(), ValueError, id="model_list"),
+        pytest.param(Mock(), {"name": "model"}, VibeCheckConfig(), ValueError, id="model_dict"),
+
+        # Invalid config types - VibeCheck validates and raises TypeError
+        pytest.param(Mock(), "test-model", "not_a_dict_or_config", TypeError, id="config_string"),
+        pytest.param(Mock(), "test-model", 123, TypeError, id="config_int"),
+        pytest.param(Mock(), "test-model", ["config"], TypeError, id="config_list"),
+        pytest.param(Mock(), "test-model", True, TypeError, id="config_bool"),
+    ],
+)
+def test_vibecheck_invalid_init(client, model, config, error_type):
+    """Ensure VibeCheck raises appropriate errors for invalid initialization parameters."""
+    with pytest.raises(error_type):
+        VibeCheck(client, model, config=config)


### PR DESCRIPTION
#### Description

This PR adds comprehensive unit tests for the `VibeCheck` class to ensure appropriate errors are raised when initialized with invalid parameter types, as requested in Issue #2.


Closes #2 

#### What change does this PR introduce?

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD (updates related to the CI/CD process)
- [ ] Documentation update (changes to docs/code comments)
- [ ] Chore (miscellaneous tasks that do not fall into the above options)

#### What is the proposed approach?

The existing test suite lacked coverage for error handling when `VibeCheck` is initialized with invalid parameter types (`client`, `model`, `config`).

1. Added a new parametrized test `test_vibecheck_invalid_init()` using `pytest.mark.parametrize` to cover multiple error scenarios in a maintainable way
2. Added validation logic to `VibeCheck` to explicitly validate model and config parameters:
- `model`: Must be a non-empty string (raises `ValueError` if not)
- `config`: Must be `VibeCheckConfig`, `dict`, or `None` (raises `TypeError` if not)
- `client`: Validation delegated to `VibeLlmClient` which raises `VibeLlmClientException` for invalid types

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)